### PR TITLE
create_basic_cord

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,16 @@
 class ApplicationController < ActionController::Base
+  before_action :basic_auth,  if: :production?
+  protect_from_forgery with: :exception
+
+  private
+
+  def production?
+    Rails.env.production?
+  end
+
+  def basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+    end
+  end
 end

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -8,6 +8,9 @@
 # server "db.example.com", user: "deploy", roles: %w{db}
 server '54.168.98.247', user: 'ec2-user', roles: %w{app db web}
 
+set :rails_env, "production"
+set :unicorn_rack_env, "production"
+
 
 # role-based syntax
 # ==================


### PR DESCRIPTION
#What 

本番環境のみBasic認証の実装。

#Why 

Idとpassを知っているユーザーのみ閲覧できるようにするため。